### PR TITLE
fix: disable ephemeral session to enable cookie sharing

### DIFF
--- a/ios/Plugin/CapacitorWebAuthPlugin.swift
+++ b/ios/Plugin/CapacitorWebAuthPlugin.swift
@@ -38,8 +38,8 @@ public class CapacitorWebAuthPlugin: CAPPlugin, ASWebAuthenticationPresentationC
         })
         
         authVC.presentationContextProvider = self
-        authVC.prefersEphemeralWebBrowserSession = true
-        
+        authVC.prefersEphemeralWebBrowserSession = false
+
         DispatchQueue.main.async {
             authVC.start()
         }


### PR DESCRIPTION
Set prefersEphemeralWebBrowserSession to false to allow ASWebAuthenticationSession to share cookies with Safari.

This enables users to utilize their existing logged-in sessions from Safari, which is essential for SSO functionality.

When prefersEphemeralWebBrowserSession is true (previous behavior):
- Session is isolated and cookies are not shared
- Users must log in again even if already authenticated in Safari

When false (new behavior):
- Session shares cookies with Safari
- Users can leverage existing authentication sessions
- Better UX for SSO scenarios